### PR TITLE
Update python-jose to 3.4.0 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ sqlalchemy==2.0.23
 alembic==1.13.1
 
 # Authentication and security
-python-jose[cryptography]==3.3.0
+python-jose[cryptography]==3.4.0
 passlib[bcrypt]==1.7.4
 python-decouple==3.8
 


### PR DESCRIPTION
- Upgraded python-jose[cryptography] from 3.3.0 to 3.4.0
- Verified all tests pass after upgrade